### PR TITLE
Allow laravel 5 integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/filesystem": "4.2.*",
-        "illuminate/support": "4.2.*"
+        "illuminate/filesystem": "4.*|5.0.*",
+        "illuminate/support": "4.*|5.0.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
Add support for laravel 5, since pingpong-labs/modules can, but now as this one is a dependency it doesn't work.
